### PR TITLE
Integration with JaCoCo and SonarCloud

### DIFF
--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -2,10 +2,11 @@ name: Code quality check
 
 on:
   push:
-    branches: [ sonar-integration ]
+    branches:
+      - '**'
   pull_request:
-    branches: [ sonar-integration ]
-    types: [opened, synchronize, reopened]
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -1,0 +1,45 @@
+name: Code quality check
+
+on:
+  push:
+    branches: [ sonar-integration ]
+  pull_request:
+    branches: [ sonar-integration ]
+    types: [opened, synchronize, reopened]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0  # Shallow clones should be disabled for a better relevancy of sonarqube analysis
+      - name: Set up JDK 11
+        uses: actions/setup-java@v2
+        with:
+          java-version: '11'
+          distribution: 'adopt'
+      - name: Build with Maven
+        run: mvn clean -fae -X -pl \!client,\!static,\!server,\!rp-spring-boot jacoco:prepare-agent test install jacoco:report
+
+        # Runs a set of commands using the runners shell
+
+      - name: Cache SonarCloud packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.sonar/cache
+          key: ${{ runner.os }}-sonar
+          restore-keys: ${{ runner.os }}-sonar
+      - name: Cache Maven packages
+        uses: actions/cache@v1
+        with:
+          path: ~/.m2
+          key: ${{ runner.os }}-m2-${{ hashFiles('**/pom.xml') }}
+          restore-keys: ${{ runner.os }}-m2
+      - name: Build and analyze
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/.github/workflows/code-quality-check.yml
+++ b/.github/workflows/code-quality-check.yml
@@ -42,4 +42,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}  # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn -B -pl \!client,\!static,\!server,\!rp-spring-boot verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,10 @@
 
 		<!-- argLine property needs to stay as POM property so that JaCoCo plugin can append it at build time -->
 		<argLine>-Xms1024m -Xmx2048m -XX:+DisableExplicitGC</argLine>
+
+		<sonar.projectKey>JanssenProject_jans-auth-server</sonar.projectKey>
+		<sonar.organization>janssenproject</sonar.organization>
+		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	</properties>
 
 	<prerequisites>

--- a/pom.xml
+++ b/pom.xml
@@ -49,6 +49,9 @@
         <arquillian.drone.version>2.0.0.Final</arquillian.drone.version>
         <arquillian.graphene.version>2.1.0.CR1</arquillian.graphene.version>
 		<shrinkwrap.version>2.1.0</shrinkwrap.version>
+
+		<!-- argLine property needs to stay as POM property so that JaCoCo plugin can append it at build time -->
+		<argLine>-Xms1024m -Xmx2048m -XX:+DisableExplicitGC</argLine>
 	</properties>
 
 	<prerequisites>
@@ -658,7 +661,7 @@
 					<artifactId>maven-surefire-plugin</artifactId>
 					<version>2.19.1</version>
 					<configuration>
-						<argLine>-Xms1024m -Xmx2048m -XX:+DisableExplicitGC</argLine>
+						<argLine>@{argLine}</argLine>
 
 						<!-- Needed as we have both junit and testng -->
 						<failIfNoTests>false</failIfNoTests>
@@ -715,6 +718,11 @@
 					<groupId>org.owasp</groupId>
 					<artifactId>dependency-check-maven</artifactId>
 					<version>5.2.2</version>
+				</plugin>
+				<plugin>
+					<groupId>org.jacoco</groupId>
+					<artifactId>jacoco-maven-plugin</artifactId>
+					<version>0.8.7</version>
 				</plugin>
 			</plugins>
 		</pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -54,6 +54,7 @@
 		<argLine>-Xms1024m -Xmx2048m -XX:+DisableExplicitGC</argLine>
 
 		<sonar.projectKey>JanssenProject_jans-auth-server</sonar.projectKey>
+		<sonar.moduleKey>${project.groupId}:${project.artifactId}</sonar.moduleKey>
 		<sonar.organization>janssenproject</sonar.organization>
 		<sonar.host.url>https://sonarcloud.io</sonar.host.url>
 	</properties>


### PR DESCRIPTION
This PR integrates jans-auth-server repo with SonarCloud and adds JaCoCo as code coverage tool for Java code.

It also adds a new workflow `Code quality check` to the repo. This workflow will perform static code analysis, run tests, report code coverage to SonarCloud.

After the first successful execution of the workflow, one can find the code quality data [here](https://sonarcloud.io/summary/new_code?id=JanssenProject_jans-auth-server).

`TODO`: Currently the code coverage reported will be low as build will skip *server* and *client* modules whose tests are failing on my local setup. I need to find out how to do a local workspace setup where tests for both module would pass and then configure Github action build in same way so that tests from both these modules can be executed and real code coverage can be reported. 