### PR TITLE
feat: corrected error expected by par during redirect_uri validation fapi1-advanced-final-ensure-registered-redirect-uri

### DIFF
--- a/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceValidator.java
+++ b/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceValidator.java
@@ -277,8 +277,12 @@ public class AuthorizeRestWebServiceValidator {
         }
     }
 
-    public String validateRedirectUri(@NotNull Client client, @Nullable String redirectUri, String state,
-                                      String deviceAuthzUserCode, HttpServletRequest httpRequest) {
+    public String validateRedirectUri(@NotNull Client client, @Nullable String redirectUri, @Nullable String state, @Nullable String deviceAuthzUserCode, @Nullable HttpServletRequest httpRequest) {
+        return validateRedirectUri(client, redirectUri, state, deviceAuthzUserCode, httpRequest, AuthorizeErrorResponseType.INVALID_REQUEST_REDIRECT_URI);
+    }
+
+    public String validateRedirectUri(@NotNull Client client, @Nullable String redirectUri, @Nullable String state,
+                                      @Nullable String deviceAuthzUserCode, @Nullable HttpServletRequest httpRequest, @NotNull AuthorizeErrorResponseType error) {
         if (StringUtils.isNotBlank(deviceAuthzUserCode)) {
             DeviceAuthorizationCacheControl deviceAuthorizationCacheControl = deviceAuthorizationService
                     .getDeviceAuthzByUserCode(deviceAuthzUserCode);
@@ -291,7 +295,7 @@ public class AuthorizeRestWebServiceValidator {
         }
         throw new WebApplicationException(Response
                 .status(Response.Status.BAD_REQUEST)
-                .entity(errorResponseFactory.getErrorAsJson(AuthorizeErrorResponseType.INVALID_REQUEST_REDIRECT_URI, state, ""))
+                .entity(errorResponseFactory.getErrorAsJson(error, state, ""))
                 .build());
     }
 

--- a/server/src/main/java/io/jans/as/server/par/ws/rs/ParRestWebService.java
+++ b/server/src/main/java/io/jans/as/server/par/ws/rs/ParRestWebService.java
@@ -2,6 +2,7 @@ package io.jans.as.server.par.ws.rs;
 
 import io.jans.as.common.model.registration.Client;
 import io.jans.as.common.util.RedirectUri;
+import io.jans.as.model.authorize.AuthorizeErrorResponseType;
 import io.jans.as.model.authorize.AuthorizeRequestParam;
 import io.jans.as.model.common.ComponentType;
 import io.jans.as.model.common.ResponseMode;
@@ -120,7 +121,7 @@ public class ParRestWebService {
             Client client = authorizeRestWebServiceValidator.validateClient(clientId, state, true);
 
             redirectUri = getRedirectUri(redirectUri, request);
-            redirectUri = authorizeRestWebServiceValidator.validateRedirectUri(client, redirectUri, state, null, httpRequest);
+            redirectUri = authorizeRestWebServiceValidator.validateRedirectUri(client, redirectUri, state, null, httpRequest, AuthorizeErrorResponseType.INVALID_REQUEST);
 
             RedirectUriResponse redirectUriResponse = new RedirectUriResponse(new RedirectUri(redirectUri, responseTypes, responseModeObj), state, httpRequest, errorResponseFactory);
             redirectUriResponse.setFapiCompatible(appConfiguration.getFapiCompatibility());


### PR DESCRIPTION
FAPI test refuse to accept invalid_request_redirect_uri which is accepted by normal Authorization Endpoint. We should change it to invalid_request when validate push request object.

https://www.certification.openid.net/log-detail.html?log=1CW8kLgAb0VuDPs&public=true