### PR TITLE
Feat: FAPI test suite expects error only in payload of http response (fapi1-advanced-final-ensure-request-object-without-exp-fails) #209

### DIFF
--- a/common/src/main/java/io/jans/as/common/util/RedirectUri.java
+++ b/common/src/main/java/io/jans/as/common/util/RedirectUri.java
@@ -21,15 +21,25 @@ import io.jans.as.model.jwt.JwtType;
 import io.jans.as.model.util.Util;
 import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang.StringUtils;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.json.JSONObject;
 
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
 import java.security.PublicKey;
-import java.util.*;
+import java.util.Calendar;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.StringTokenizer;
 
-import static io.jans.as.model.authorize.AuthorizeResponseParam.*;
+import static io.jans.as.model.authorize.AuthorizeResponseParam.AUD;
+import static io.jans.as.model.authorize.AuthorizeResponseParam.EXP;
+import static io.jans.as.model.authorize.AuthorizeResponseParam.EXPIRES_IN;
+import static io.jans.as.model.authorize.AuthorizeResponseParam.ISS;
+import static io.jans.as.model.authorize.AuthorizeResponseParam.RESPONSE;
 
 /**
  * @author Javier Rojas Blum
@@ -91,6 +101,11 @@ public class RedirectUri {
         if (StringUtils.isNotBlank(key)) {
             responseParameters.put(key, value);
         }
+    }
+
+    @Nullable
+    public String getResponseParameter(@NotNull String key) {
+        return responseParameters.get(key);
     }
 
     public String getIssuer() {

--- a/model/src/main/java/io/jans/as/model/error/DefaultErrorResponse.java
+++ b/model/src/main/java/io/jans/as/model/error/DefaultErrorResponse.java
@@ -13,7 +13,6 @@ package io.jans.as.model.error;
 public class DefaultErrorResponse extends ErrorResponse {
 
     private IErrorType type;
-    private String state;
 
     /**
      * Returns the error response type.
@@ -34,18 +33,9 @@ public class DefaultErrorResponse extends ErrorResponse {
     }
 
     @Override
-    public String getState() {
-        return state;
-    }
-
-    public void setState(String p_state) {
-        state = p_state;
-    }
-
-    @Override
     public String getErrorCode() {
         if (type != null)
             return type.toString();
-        return null;
+        return super.getErrorCode();
     }
 }

--- a/model/src/main/java/io/jans/as/model/error/ErrorResponse.java
+++ b/model/src/main/java/io/jans/as/model/error/ErrorResponse.java
@@ -6,13 +6,14 @@
 
 package io.jans.as.model.error;
 
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
-
 import org.apache.commons.lang.StringUtils;
 import org.apache.log4j.Logger;
 import org.json.JSONException;
 import org.json.JSONObject;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 
 /**
  * Base class for error responses.
@@ -20,14 +21,16 @@ import org.json.JSONObject;
  * @author Javier Rojas Blum
  * @version August 20, 2019
  */
-public abstract class ErrorResponse {
+public class ErrorResponse {
 
-    private final static Logger log = Logger.getLogger(ErrorResponse.class);
+    private static final Logger log = Logger.getLogger(ErrorResponse.class);
 
 	private int status;
+	private String errorCode;
 	private String errorDescription;
 	private String errorUri;
 	private String reason;
+	private String state;
 
 	/**
 	 * Return the HTTP response status code.
@@ -48,21 +51,20 @@ public abstract class ErrorResponse {
 	}
 
 	/**
-	 * Returns the error code of the response.
-	 *
-	 * @return The error code.
-	 */
-	public abstract String getErrorCode();
-
-	/**
 	 * If a valid state parameter was present in the request, it returns the
 	 * exact value received from the client.
 	 *
 	 * @return The state value of the request.
 	 */
-	public abstract String getState();
+	public String getState() {
+	    return state;
+    }
 
-	/**
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    /**
 	 * Returns a human-readable UTF-8 encoded text providing additional
 	 * information, used to assist the client developer in understanding the
 	 * error that occurred.
@@ -117,6 +119,19 @@ public abstract class ErrorResponse {
     }
 
     /**
+     * Returns the error code of the response.
+     *
+     * @return The error code.
+     */
+    public String getErrorCode() {
+        return errorCode;
+    }
+
+    public void setErrorCode(String errorCode) {
+        this.errorCode = errorCode;
+    }
+
+    /**
 	 * Returns a query string representation of the object.
 	 *
 	 * @return The object represented in a query string.
@@ -129,16 +144,16 @@ public abstract class ErrorResponse {
 
 			if (errorDescription != null && !errorDescription.isEmpty()) {
 				queryStringBuilder.append("&error_description=").append(
-						URLEncoder.encode(errorDescription, "UTF-8"));
+						URLEncoder.encode(errorDescription, StandardCharsets.UTF_8.name()));
 			}
 
 			if (errorUri != null && !errorUri.isEmpty()) {
 				queryStringBuilder.append("&error_uri=").append(
-						URLEncoder.encode(errorUri, "UTF-8"));
+						URLEncoder.encode(errorUri, StandardCharsets.UTF_8.name()));
 			}
 
             if (StringUtils.isNotBlank(reason)) {
-                queryStringBuilder.append("&reason=").append(URLEncoder.encode(reason, "UTF-8"));
+                queryStringBuilder.append("&reason=").append(URLEncoder.encode(reason, StandardCharsets.UTF_8.name()));
             }
 
 			if (getState() != null && !getState().isEmpty()) {

--- a/model/src/main/java/io/jans/as/model/error/ErrorResponseFactory.java
+++ b/model/src/main/java/io/jans/as/model/error/ErrorResponseFactory.java
@@ -22,6 +22,8 @@ import io.jans.as.model.token.TokenRevocationErrorResponseType;
 import io.jans.as.model.uma.UmaErrorResponseType;
 import io.jans.as.model.userinfo.UserInfoErrorResponseType;
 import io.jans.as.model.util.Util;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,7 +108,7 @@ public class ErrorResponseFactory implements Configuration {
             return;
         }
 
-        log.info("Component is disabled, type:" + componentType);
+        log.info("Component is disabled, type: {}", componentType);
 
         throw new WebApplicationException(Response
                 .status(Response.Status.FORBIDDEN)
@@ -120,6 +122,22 @@ public class ErrorResponseFactory implements Configuration {
                 .status(status)
                 .entity(errorAsJson(type, reason))
                 .type(MediaType.APPLICATION_JSON_TYPE)
+                .build());
+    }
+
+    @NotNull
+    public WebApplicationException createBadRequestException(@NotNull ErrorResponse error) {
+        throw new WebApplicationException(Response
+                .status(Response.Status.BAD_REQUEST)
+                .entity(error.toJSonString())
+                .build());
+    }
+
+    @NotNull
+    public WebApplicationException createBadRequestException(@NotNull IErrorType error, @Nullable String state) {
+        throw new WebApplicationException(Response
+                .status(Response.Status.BAD_REQUEST)
+                .entity(getErrorAsJson(error, state, ""))
                 .build());
     }
 


### PR DESCRIPTION
Background of issue is following : AS at Authorization Endpoint validates request parameters and if validation fail AS returns error as 302 redirect with inlined error code and description in response url [as specified in spec](https://openid.net/specs/openid-connect-core-1_0.html#AuthError).

```
HTTP/1.1 302 Found
Location: https://client.example.org/cb?error=invalid_request&error_description=Unsupported%20response_type%20value&state=af0ifjsldkj
```

PAR reuses Authorization Endpoint validator and as result returns error as redirect. However FAPI Test Suite refuse to accept error response as redirect (302). Instead it expects backchannel 400 with error as payload.

It means we have to add way to Authorization Endpoint validator for PAR return error with 400 and http status code and error in payload of response.

https://www.certification.openid.net/log-detail.html?log=ycFsosKKDVKA4GZ&public=true

https://github.com/JanssenProject/jans-auth-server/issues/209