### PR TITLE
fix(jans): removed filtering of stat endpoint

### DIFF
--- a/server/src/main/java/io/jans/as/server/auth/AuthenticationFilter.java
+++ b/server/src/main/java/io/jans/as/server/auth/AuthenticationFilter.java
@@ -70,7 +70,6 @@ import static io.jans.as.model.ciba.BackchannelAuthenticationErrorResponseType.I
                 "/restv1/revoke_session",
                 "/restv1/bc-authorize",
                 "/restv1/par",
-                "/restv1/internal/*",
                 "/restv1/device_authorization"},
         displayName = "oxAuth")
 public class AuthenticationFilter implements Filter {


### PR DESCRIPTION
Authorization is checked inside WS.

https://github.com/GluuFederation/oxAuth/issues/1565