### PR TITLE
fix: changed error code 401 -> 400 for pkce failure

### DIFF
--- a/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImpl.java
+++ b/server/src/main/java/io/jans/as/server/token/ws/rs/TokenRestWebServiceImpl.java
@@ -669,7 +669,7 @@ public class TokenRestWebServiceImpl implements TokenRestWebService {
         if (!CodeVerifier.matched(grant.getCodeChallenge(), grant.getCodeChallengeMethod(), codeVerifier)) {
             log.error("PKCE check fails. Code challenge does not match to request code verifier, " +
                     "grantId:" + grant.getGrantId() + ", codeVerifier: " + codeVerifier);
-            throw new WebApplicationException(response(error(401, TokenErrorResponseType.INVALID_GRANT, "PKCE check fails. Code challenge does not match to request code verifier."), oAuth2AuditLog));
+            throw new WebApplicationException(response(error(400, TokenErrorResponseType.INVALID_GRANT, "PKCE check fails. Code challenge does not match to request code verifier."), oAuth2AuditLog));
         }
     }
 


### PR DESCRIPTION
Changed error code 401 -> 400 for pkce failure

fapi1-advanced-final-ensure-pkce-code-verifier-required
fapi1-advanced-final-incorrect-pkce-code-verifier-rejected

 https://www.certification.openid.net/log-detail.html?log=vOViBxY9hlaw9os&public=true