### PR TITLE
fix: changed error code 401 -> 400 for pkce failure

### DIFF
--- a/client/src/test/java/io/jans/as/client/ws/rs/PkceHttpTest.java
+++ b/client/src/test/java/io/jans/as/client/ws/rs/PkceHttpTest.java
@@ -199,7 +199,7 @@ public class PkceHttpTest extends BaseTest {
         TokenResponse tokenResponse = tokenClient.exec();
 
         showClient(tokenClient);
-        assertEquals(tokenResponse.getStatus(), 401, "Unexpected response code: " + tokenResponse.getStatus());
+        assertEquals(tokenResponse.getStatus(), 400, "Unexpected response code: " + tokenResponse.getStatus());
         assertNull(tokenResponse.getAccessToken(), "The access token is null");
 
         // 5. Get Access Token without code verifier
@@ -209,7 +209,7 @@ public class PkceHttpTest extends BaseTest {
         tokenResponse = tokenClient.exec();
 
         showClient(tokenClient);
-        assertEquals(tokenResponse.getStatus(), 401, "Unexpected response code: " + tokenResponse.getStatus());
+        assertEquals(tokenResponse.getStatus(), 400, "Unexpected response code: " + tokenResponse.getStatus());
         assertNull(tokenResponse.getAccessToken(), "The access token is null");
 
     }

--- a/server/src/main/java/io/jans/as/server/service/SessionIdService.java
+++ b/server/src/main/java/io/jans/as/server/service/SessionIdService.java
@@ -195,7 +195,7 @@ public class SessionIdService {
             String sessionAcr = getAcr(session);
 
             if (StringUtils.isBlank(sessionAcr)) {
-                log.trace("Failed to fetch acr from session, attributes: " + sessionAttributes);
+                log.trace("Failed to fetch acr from session, attributes: {}", sessionAttributes);
                 return session;
             }
 
@@ -329,10 +329,8 @@ public class SessionIdService {
     public SessionId getSessionId() {
         String sessionId = cookieService.getSessionIdFromCookie();
 
-        if (StringHelper.isEmpty(sessionId)) {
-        	if (identity.getSessionId() != null) {
-        		sessionId = identity.getSessionId().getId();
-        	}
+        if (StringHelper.isEmpty(sessionId) && identity.getSessionId() != null) {
+      		sessionId = identity.getSessionId().getId();
         }
 
         if (StringHelper.isNotEmpty(sessionId)) {


### PR DESCRIPTION
Changed error code 401 -> 400 for pkce failure

fapi1-advanced-final-ensure-pkce-code-verifier-required
fapi1-advanced-final-incorrect-pkce-code-verifier-rejected

 https://www.certification.openid.net/log-detail.html?log=vOViBxY9hlaw9os&public=true

 related to https://github.com/JanssenProject/jans-auth-server/commit/0cab05c1a295647da948296c1ac0a2604558a44e