### PR TITLE
fix : don't fail entire discovery if DPoP config is missed

### DIFF
--- a/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
+++ b/model/src/main/java/io/jans/as/model/configuration/AppConfiguration.java
@@ -2378,6 +2378,7 @@ public class AppConfiguration implements Configuration {
     }
 
     public List<String> getDpopSigningAlgValuesSupported() {
+        if (dpopSigningAlgValuesSupported == null) dpopSigningAlgValuesSupported = new ArrayList<>();
         return dpopSigningAlgValuesSupported;
     }
 


### PR DESCRIPTION
fix : don't fail entire discovery if DPoP config is missed

https://github.com/JanssenProject/jans-auth-server/issues/264