### PR TITLE
fix: CrossEncryptionTest starts to fail after DPoP merge #269

### DIFF
--- a/model/src/main/java/io/jans/as/model/jwt/JwtType.java
+++ b/model/src/main/java/io/jans/as/model/jwt/JwtType.java
@@ -30,7 +30,7 @@ public enum JwtType {
     public static JwtType fromString(String param) {
         if (param != null) {
             for (JwtType t : JwtType.values()) {
-                if (param.equals(t.paramName)) {
+                if (param.equalsIgnoreCase(t.paramName)) {
                     return t;
                 }
             }

--- a/model/src/test/java/io/jans/as/model/jwt/JwtTypeTest.java
+++ b/model/src/test/java/io/jans/as/model/jwt/JwtTypeTest.java
@@ -1,0 +1,30 @@
+package io.jans.as.model.jwt;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+
+/**
+ * @author Yuriy Zabrovarnyy
+ */
+public class JwtTypeTest {
+
+    @Test
+    public void fromString_withDifferentCasesSensitiveValues_shouldReturnCorrectValue() {
+        assertEquals(JwtType.fromString("jwt"), JwtType.JWT);
+        assertEquals(JwtType.fromString("Jwt"), JwtType.JWT);
+        assertEquals(JwtType.fromString("JWT"), JwtType.JWT);
+
+        assertEquals(JwtType.fromString("dpop+jwt"), JwtType.DPOP_PLUS_JWT);
+        assertEquals(JwtType.fromString("Dpop+jwt"), JwtType.DPOP_PLUS_JWT);
+        assertEquals(JwtType.fromString("DPOP+JWT"), JwtType.DPOP_PLUS_JWT);
+    }
+
+    @Test
+    public void fromString_withBlankValue_shouldReturnNull() {
+        assertNull(JwtType.fromString(null));
+        assertNull(JwtType.fromString(""));
+        assertNull(JwtType.fromString("  "));
+    }
+}

--- a/server/src/test/java/io/jans/as/server/comp/CrossEncryptionTest.java
+++ b/server/src/test/java/io/jans/as/server/comp/CrossEncryptionTest.java
@@ -369,8 +369,8 @@ public class CrossEncryptionTest {
 
         final String jweString = jweObject.serialize();
 
-        decryptAndValidateSignatureWithGluu(jweString);
         decryptAndValidateSignatureWithNimbus(jweString);
+        decryptAndValidateSignatureWithGluu(jweString);
     }
 
     @Test
@@ -461,7 +461,7 @@ public class CrossEncryptionTest {
         decrypter.setBlockEncryptionAlgorithm(BlockEncryptionAlgorithm.A128GCM);
 
         final Jwe jwe = decrypter.decrypt(jweString);
-        assertEquals(JwtType.JWT, jwe.getHeader().getContentType());
+        assertEquals(jwe.getHeader().getContentType(), JwtType.JWT);
 
         final Jwt jwt = jwe.getSignedJWTPayload();
 


### PR DESCRIPTION
fix: CrossEncryptionTest starts to fail after DPoP merge #269

Problem was in JwtType changes. Fixed and covered with JwtTypeTest. CrossEncryptionTest is successful again.