### PR TITLE
fix: do not return state in response if PAR does not contain state

### DIFF
--- a/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
+++ b/server/src/main/java/io/jans/as/server/authorize/ws/rs/AuthorizeRestWebServiceImpl.java
@@ -264,10 +264,14 @@ public class AuthorizeRestWebServiceImpl implements AuthorizeRestWebService {
             codeChallenge = par.getAttributes().getCodeChallenge();
             codeChallengeMethod = par.getAttributes().getCodeChallengeMethod();
 
+            if (StringUtils.isNotBlank(par.getAttributes().getState())) {
+                state = par.getAttributes().getState();
+            } else {
+                state = "";
+            }
+
             if (StringUtils.isNotBlank(par.getAttributes().getNonce()))
                 nonce = par.getAttributes().getNonce();
-            if (StringUtils.isNotBlank(par.getAttributes().getState()))
-                state = par.getAttributes().getState();
             if (StringUtils.isNotBlank(par.getAttributes().getSessionId()))
                 sessionId = par.getAttributes().getSessionId();
             if (StringUtils.isNotBlank(par.getAttributes().getCustomResponseHeaders()))


### PR DESCRIPTION
 Do not return state in response if PAR does not contain state(even if state is passed in the url parameters to the authorization endpoint ). (FAPI)

 #272