### PR TITLE
fix: jwks error for OKP key

### DIFF
--- a/model/src/main/java/io/jans/as/model/jwk/JSONWebKey.java
+++ b/model/src/main/java/io/jans/as/model/jwk/JSONWebKey.java
@@ -297,6 +297,20 @@ public class JSONWebKey {
 
             byte[] hash = JwtUtil.getMessageDigestSHA256(jwkStr);
             result = Base64Util.base64urlencode(hash);
+        } else if (kty == KeyType.OKP) {
+            if (crv == null) throw new JWKException("The crv is required");
+            if (x == null) throw new JWKException("The x is required");
+
+            String jwkStr = new StringBuilder()
+                    .append("{")
+                    .append("\"crv\":").append("\"").append(crv).append("\",")
+                    .append("\"kty\":").append("\"").append(kty).append("\",")
+                    .append("\"x\":").append("\"").append(y).append("\"")
+                    .append("}")
+                    .toString();
+
+            byte[] hash = JwtUtil.getMessageDigestSHA256(jwkStr);
+            result = Base64Util.base64urlencode(hash);
         } else throw new JWKException("Thumbprint not supported for the kty");
 
         return result;


### PR DESCRIPTION
Hello @yuriyz, request you to please review and merge the changes for  jwkThumbprint for OKP.
This should resolve the jans-config-api jenkins build issue.
Error as per logs: `com.nimbusds.jose.jwk.JWKException: Thumbprint not supported for the kty`
Changes done are as per https://datatracker.ietf.org/doc/html/rfc8037#appendix-A.3
I have tested the fix locally