### PR TITLE
fix(jans-auth-server): don't try to re-generate keys for symetric algorithms

### DIFF
--- a/model/src/main/java/io/jans/as/model/crypto/AbstractCryptoProvider.java
+++ b/model/src/main/java/io/jans/as/model/crypto/AbstractCryptoProvider.java
@@ -130,10 +130,18 @@ public abstract class AbstractCryptoProvider {
 
         for (Algorithm alg : Algorithm.values()) {
             try {
-                if (!allowedAlgs.isEmpty() && !allowedAlgs.contains(alg.getParamName())) {
-                    LOG.debug(String.format("Key generation for %s is skipped because it's not allowed by keyAlgsAllowedForGeneration configuration property.", alg.toString()));
+                final boolean isNotAllowed = !allowedAlgs.isEmpty() && !allowedAlgs.contains(alg.getParamName());
+                final boolean isNotSupported = !alg.canGenerateKeys();
+                if (isNotAllowed || isNotSupported) {
+                    if (isNotAllowed) {
+                        LOG.debug(String.format("Key generation for %s is skipped because it's not allowed by keyAlgsAllowedForGeneration configuration property.", alg.toString()));
+                    }
+                    if (isNotSupported) {
+                        LOG.trace(alg + " does not support keys re-generation.");
+                    }
                     continue;
                 }
+
                 keys.put(cryptoProvider.generateKey(alg, expiration));
             } catch (Exception ex) {
                 LOG.error(String.format("Algorithm: %s", alg), ex);

--- a/model/src/main/java/io/jans/as/model/jwk/Algorithm.java
+++ b/model/src/main/java/io/jans/as/model/jwk/Algorithm.java
@@ -116,6 +116,10 @@ public enum Algorithm {
         return family;
     }
 
+    public boolean canGenerateKeys() { // based on currently supported generator, see io.jans.as.model.crypto.AuthCryptoProvider.generateKeyEncryption
+        return family == AlgorithmFamily.RSA || family == AlgorithmFamily.EC;
+    }
+
     /**
      * Returns the corresponding {@link Algorithm} for a parameter.
      *


### PR DESCRIPTION
fix(jans-auth-server): don't try to re-generate keys for symetric algorithms

https://github.com/JanssenProject/jans-auth-server/issues/373